### PR TITLE
Allow null values in IMeasureResult.cells

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -96,7 +96,7 @@ export interface IHeaderMeasureResult {
 }
 
 export interface IMeasureResult {
-    cells?: ICellMeasureResult[];
+    cells?: (ICellMeasureResult|null)[];
     headers?: IHeaderMeasureResult[];
 }
 


### PR DESCRIPTION
Looking at the examples [1] It's ok for null to used here.

[1] - https://papasnippy.github.io/react-bolivianite-grid/examples/autosizing